### PR TITLE
Fixes

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -154,15 +154,19 @@ bool ProcessEvents(phys::System* sys) {
         lctrl = true; 
       } else if (ev.key.keysym.sym == SDLK_RCTRL) {
         rctrl = true; 
-      } else if (dragged != nullptr) {
+      } else {
+	phys::Object* shifted = sys->LastMoved();
+	if (sys->InToolbar(shifted)) {
+	  continue;
+	}
         if (ev.key.keysym.sym == SDLK_DOWN) {
-          dragged->Shift(0, 5);
+          shifted->Shift(0, 5);
         } else if (ev.key.keysym.sym == SDLK_UP) {
-          dragged->Shift(0, -5);
+          shifted->Shift(0, -5);
         } else if (ev.key.keysym.sym == SDLK_LEFT) {
-          dragged->Shift(-5, 0);
+          shifted->Shift(-5, 0);
         } else if (ev.key.keysym.sym == SDLK_RIGHT) {
-          dragged->Shift(5, 0);
+          shifted->Shift(5, 0);
         }
       }
     } else if (ev.type == SDL_KEYUP) {

--- a/main.cc
+++ b/main.cc
@@ -144,7 +144,7 @@ bool ProcessEvents(phys::System* sys) {
       if (dragged->isToolbar()) {
         continue;
       }
-      if (lctrl || rctrl) {
+      if ((lctrl || rctrl) && !sys->InToolbar(dragged)) {
         dragged->Resize(ev.motion.x, ev.motion.y, ev.motion.xrel, ev.motion.yrel);
       } else {
         dragged->Shift(ev.motion.xrel, ev.motion.yrel);

--- a/phys/system.h
+++ b/phys/system.h
@@ -185,6 +185,10 @@ class System {
     }
   }
 
+  Object* LastMoved() {
+    return objs_.back(); 
+      };
+
   Object* ObjectFor(int x, int y) {
     for (int i = objs_.size() - 1; i >= 0; --i) {
       if (objs_[i]->Contains(x, y)) {


### PR DESCRIPTION
Fixes problem with being able to move object. Just grabs the last moved object from the system. 

Also turns off re-sizing of toolbar items so the toolbar doesn't accidentally get cluttered. 
